### PR TITLE
ITEA fixes

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -3,6 +3,7 @@ conda env create -f environment.yml
 
 eval "$(conda shell.bash hook)"
 
+conda init bash
 conda activate srbench
 conda info 
 

--- a/environment.yml
+++ b/environment.yml
@@ -22,6 +22,11 @@ dependencies:
     - pytest
     - matplotlib
     - pip=20.3.3 
+    - libblas=3.9.0=8_openblas # itea
+    - liblapack=3.9.0=8_openblas # itea
+    - gmp=6.2.1=h58526e2_0 # itea
+    - gsl=2.6=he838d99_2 # itea
+    - libffi=3.3=h58526e2_2 # itea
     - pip:
         - DistanceClassifier==0.0.8 # ellyn
         - pmlb==1.0.1.post3

--- a/experiment/methods/ITEARegressor.py
+++ b/experiment/methods/ITEARegressor.py
@@ -1,22 +1,42 @@
-from .src.ITEA import itea
+from .src.ITEA import itea_srbench as itea
 from itertools import product
-
-es = [(-5, 5), (0, 5), (-2, 2), (0, 2)]
-ts = [(2, 10), (2, 15), (2, 5)]
-nzs = [1]
-tss = [ '[Id]', '[Id, Tanh, Sin, Cos, Log, Exp, SqrtAbs]', '[Id, Sin]']
 
 hyper_params = [
     {
-        'exponents': (e,),
-        'termlimit':(t,), 'nonzeroexps': (nz,),
-        'transfunctions':(ts,),
-    } for e, t, nz, ts in product(es, ts, nzs, tss)
+        'exponents' : ((0,5),),
+        'termlimit' : ((2,5),),
+        'transfunctions' : ('[Id, Sin]',)
+    },
+    {
+        'exponents' : ((0,5),),
+        'termlimit' : ((2, 15),),
+        'transfunctions' : ('[Id, Sin]',)
+    },
+    {
+        'exponents' : ((-5,5),),
+        'termlimit' : ((2, 15),),
+        'transfunctions' : ('[Id, Sin]',)
+    },
+    {
+        'exponents' : ((-5, 5),),
+        'termlimit' : ((2, 5),),
+        'transfunctions' : ('[Id, Tanh, Sin, Cos, Log, Exp, SqrtAbs]',)
+    },
+    {
+        'exponents' : ((0, 5),),
+        'termlimit' : ((2, 15),),
+        'transfunctions' : ('[Id, Tanh, Sin, Cos, Log, Exp, SqrtAbs]',)
+    },
+    {
+        'exponents' : ((-5, 5),),
+        'termlimit' : ((2, 15),),
+        'transfunctions' : ('[Id, Tanh, Sin, Cos, Log, Exp, SqrtAbs]',)
+    },
 ]
 
 # Create the pipeline for the model
 eval_kwargs = {'scale_x': False, 'scale_y': False}
-est = itea.ITEARegressor(npop=500, ngens=200, exponents=(-1, 1), termlimit=(2, 2))
+est = itea.ITEARegressor(npop=1000, ngens=500, exponents=(-1, 1), termlimit=(2, 2), nonzeroexps=1)
 
 def complexity(e):
     return e.len

--- a/experiment/methods/src/itea_install.sh
+++ b/experiment/methods/src/itea_install.sh
@@ -8,6 +8,7 @@ fi
 git clone https://github.com/folivetti/ITEA.git
 
 cd ITEA
-curl -sSL https://get.haskellstack.org/ | sh
-stack build
+#curl -sSL https://get.haskellstack.org/ | sh
+#stack build
+cp ~/.conda/envs/srbench/libgsl.so bin/libgsl.so.0
 

--- a/experiment/methods/src/itea_install.sh
+++ b/experiment/methods/src/itea_install.sh
@@ -10,7 +10,6 @@ git clone https://github.com/folivetti/ITEA.git
 cd ITEA
 #curl -sSL https://get.haskellstack.org/ | sh
 #stack build
-LIBGSL=$(ldconfig -p | grep "libgsl.so " | tr ' ' '\n' | grep /)
-#cp ~/.conda/envs/srbench/libgsl.so bin/libgsl.so.0
-cp $LIBGSL $LIBGSL.0
+conda activate srbench
+cp $CONDA_PREFIX/lib/libgsl.so bin/libgsl.so.0
 

--- a/experiment/methods/src/itea_install.sh
+++ b/experiment/methods/src/itea_install.sh
@@ -10,5 +10,7 @@ git clone https://github.com/folivetti/ITEA.git
 cd ITEA
 #curl -sSL https://get.haskellstack.org/ | sh
 #stack build
-cp ~/.conda/envs/srbench/libgsl.so bin/libgsl.so.0
+LIBGSL=$(ldconfig -p | grep "libgsl.so " | tr ' ' '\n' | grep /)
+#cp ~/.conda/envs/srbench/libgsl.so bin/libgsl.so.0
+cp $LIBGSL $LIBGSL.0
 

--- a/experiment/methods/src/itea_install.sh
+++ b/experiment/methods/src/itea_install.sh
@@ -7,9 +7,9 @@ fi
 
 git clone https://github.com/folivetti/ITEA.git
 
-cd ITEA
+#cd ITEA
 #curl -sSL https://get.haskellstack.org/ | sh
 #stack build
-conda activate srbench
-cp $CONDA_PREFIX/lib/libgsl.so bin/libgsl.so.0
+#conda activate srbench
+#cp $CONDA_PREFIX/lib/libgsl.so bin/libgsl.so.0
 


### PR DESCRIPTION
Now ITEA should work with both github actions and your HPC. It is not the best approach, but given the problem Haskell stack has with using the conda env paths, this should do.
What I have done:

- generated a binary of ITEA built into a CentOS 7 image (thanks @foolnotion)
- commited into ITEA repo the binary file, a modified python wrapper and a script that sets some env variables before running ITEA (so that it can use the libs installed in conda env)
- commited a copy of libgsl.so.0 (it would be best to copy from the conda env path, but I don't have access to this path until after the CI is done running)
- included the required libs in `environment.yml`
- include a `conda init bash` into `configure.sh`

Check if that's ok, I had to add this conda init so that the `conda activate` works inside CI and so I can use the $CONDA_PREFIX variable.