### PR TITLE
update model complexity

### DIFF
--- a/experiment/methods/OperonRegressor.py
+++ b/experiment/methods/OperonRegressor.py
@@ -80,7 +80,7 @@ hyper_params = [
     ]
 
 def complexity(est):
-    return est._stats['model_length'] # scaling nodes not counted
+    return est._stats['model_complexity'] # scaling nodes not counted
 
 def model(est, X):
     return est.get_model_string(3)

--- a/experiment/methods/src/operon_install.sh
+++ b/experiment/methods/src/operon_install.sh
@@ -15,7 +15,7 @@ fi
 git clone https://github.com/heal-research/operon
 cd operon
 # fix version
-# git checkout c537a45b5ff5f98b78821244a1fc657e2f081cb0
+git checkout 015d420944a64353a37e0493ae9be74c645b4198
 
 # run cmake
 rm -rf build


### PR DESCRIPTION
update returned complexity as discussed in #3 

after fitting the regressor generates a statistics dictionary:
```python
        self._stats = {
            'model_length':        self._model.Length - 4, # do not count scaling nodes?
            'model_complexity':    self._model.Length - 4 + 2 * n_vars,
            'generations':         gp.Generation,
            'fitness_evaluations': evaluator.FitnessEvaluations,
            'local_evaluations':   evaluator.LocalEvaluations,
            'random_state':        self.random_state
        }
```

`model_length` counts the actual tree nodes (just as before), while `model_complexity` also counts the multiplication with a weight for each variable node.